### PR TITLE
Fix Windows specific errors with links

### DIFF
--- a/packages/guider/src/client/partials/content-footer/github-edit-link.tsx
+++ b/packages/guider/src/client/partials/content-footer/github-edit-link.tsx
@@ -9,7 +9,7 @@ export function useEditLink(baseUrl: string | null | undefined): string | null {
   const parsed = gitUrlParse(baseUrl);
   let filePath = parsed.filepath;
   filePath += filePath.length > 0 ? '/' : '';
-  filePath += file.filePath;
+  filePath += file.urlSafeFilePath;
 
   // Resets the filepath as we want to manually construct it
   parsed.filepath = '';

--- a/packages/guider/src/theme/types.ts
+++ b/packages/guider/src/theme/types.ts
@@ -17,4 +17,5 @@ export type MetaMapItem = {
 export type PageMapItem = {
   sitePath: string;
   filePath: string;
+  urlSafeFilePath: string;
 };

--- a/packages/guider/src/webpack/loader/md-loader.ts
+++ b/packages/guider/src/webpack/loader/md-loader.ts
@@ -1,4 +1,3 @@
-import { parse, format } from 'node:path';
 import { compile } from '@mdx-js/mdx';
 import remarkFrontmatter from 'remark-frontmatter';
 import remarkHeadings from '@vcarl/remark-headings';
@@ -46,13 +45,24 @@ export async function mdLoader(source: string): Promise<string> {
             const hasProtocol = Boolean(url.match(/[a-zA-Z]+:/g));
             if (hasProtocol) return url;
 
-            // must be relative url
             const [path, hash] = url.split('#', 2);
-            const parsedPath = parse(path);
-            parsedPath.ext = '';
-            parsedPath.base = '';
+
+            const pathSections = path.split('/');
+            const lastSectionIndex = pathSections.length - 1;
+
+            // We get the last section so that only the last extension is removed
+            // e.g. bar.ts.mdx -> bar.ts
+            const lastDot = pathSections[lastSectionIndex].lastIndexOf('.');
+
+            // If there is no dot, there is no extension to remove so we can return the url as is
+            if (lastDot === -1) return url;
+
+            pathSections[lastSectionIndex] = pathSections[
+              lastSectionIndex
+            ].slice(0, lastDot);
+
             const hashPath = hash && hash.length > 0 ? `#${hash}` : '';
-            return `${format(parsedPath)}${hashPath}`;
+            return `${pathSections.join('/')}${hashPath}`;
           },
         },
       ],


### PR DESCRIPTION
- Changed webpack collector to normalise MSDOS path separator to UNIX when using as URL
- Added a URL safe path to webpack collector which uses URL path separators instead of MSDOS on Windows
- Fixed Windows path separator issues in MDX link rewriting - changed logic to not use the node `path` module